### PR TITLE
Generate nuget packages in AppVeyor builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,148 @@
 
 Simple Feature Toggle client for .NET.
 
-Nuget package available at [MakingSense.DopplerFeatureToggle](https://preview.nuget.org/packages/MakingSense.DopplerFeatureToggle).
+~~Nuget package available at [MakingSense.DopplerFeatureToggle](https://preview.nuget.org/packages/MakingSense.DopplerFeatureToggle)~~ (not available yet).
+
+## Pre-release NuGet feed
+
+<https://ci.appveyor.com/nuget/makingsense-aspnet> (authenticated)
+
+Authentication: 
+* user: `dtru+read@makingsense.com`
+* password: `4@pdw@BlfpQn`
+
+`NuGet.config` file example:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<clear />
+		<add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+		<add key="makingsense-aspnet" value="https://ci.appveyor.com/nuget/makingsense-aspnet" />
+	</packageSources>
+	<packageSourceCredentials>
+		<makingsense-aspnet>
+			<add key="Username" value="dtru+read@makingsense.com" />
+			<add key="ClearTextPassword" value="4@pdw@BlfpQn" />
+		</makingsense-aspnet>
+	</packageSourceCredentials>
+</configuration>
+```
+
+## Usage
+
+First, it is necessary to setup the _FeatureToggleClient_ and configure it to be updated periodically for example:
+
+```csharp
+var client = new HttpFeatureToggleClient(
+    "https://raw.githubusercontent.com/MakingSense/doppler-feature-toggle/resources/example1.json");
+
+client.UpdatePeriodically(
+    dueTime: TimeSpan.FromSeconds(10),
+    period: TimeSpan.FromMinutes(1));
+```
+
+Then, we need to configure how to access to the features using the accessors. There are two ways to do it:
+
+Using classes:
+
+```csharp
+public class BooleanFeatureAccessorDemo : FeatureToggleAccessor<bool>
+{
+    public BooleanFeatureAccessorDemo(IFeatureToggleClient featureToggleClient)
+        : base(
+            featureToggleClient,
+            featureName: "BooleanFeature",
+            defaultTreatment: "Disabled",
+            forceTreatment: null,
+            treatments: new Dictionary<string, Func<bool>>()
+            {
+                ["Disabled"] = () => false,
+                ["Enabled"] = () => true
+            })
+    {
+
+    }
+}
+
+public class DateBehaviorAccessorDemo : FeatureToggleAccessor<Func<DateTime, string>>
+{
+    public DateBehaviorAccessorDemo(IFeatureToggleClient featureToggleClient)
+        : base(
+            featureToggleClient,
+            featureName: "DateBehavior",
+            defaultTreatment: "ISO",
+            forceTreatment: null,
+            treatments: new Dictionary<string, Func<Func<DateTime, string>>>()
+            {
+                ["ISO"] = () => (date => date.ToString("yyyy-MM-dd")),
+                ["English"] = () => (date => date.ToString("MM/dd/yyyy")),
+                ["Spanish"] = () => (date => date.ToString("dd/MM/yyyy"))
+            })
+    {
+
+    }
+}
+
+// In composition root:
+
+var booleanAccessor = new BooleanFeatureAccessorDemo(client);
+var forcedBooleanAccessor = new ForcedBooleanFeatureAccessorDemo(client, "Enabled");
+var dateFormatAccessor = new DateBehaviorAccessorDemo(client);
+
+DependencyInjectionContainer.RegisterSingleton(booleanAccessor);
+DependencyInjectionContainer.RegisterSingleton(dateFormatAccessor);
+```
+
+Using builders:
+
+```csharp
+// In composition root:
+
+var booleanAccessor = client
+    .CreateFeature<bool>("BooleanFeature")
+    .AddBehavior("Disabled", false)
+    .AddBehavior("Enabled", true)
+    .SetDefaultTreatment("Disabled")
+    .ForceTreatmentIfNotNull(null)
+    .Build();
+
+var dateFormatAccessor = client
+    .CreateFeature<DateTime, string>("DateBehavior")
+    .AddBehavior("ISO", x => x.ToString("yyyy-MM-dd"))
+    .AddBehavior("English", x => x.ToString("MM/dd/yyyy"))
+    .AddBehavior("Spanish", x => x.ToString("dd/MM/yyyy"))
+    .SetDefaultTreatment("ISO")
+    .Build();
+
+DependencyInjectionContainer.RegisterSingleton(booleanAccessor);
+DependencyInjectionContainer.RegisterSingleton(dateFormatAccessor);
+```
+
+Take into account that these examples are only to simplify, in general is not a good idea to resolve booleans.
+
+Finally, we could use the accessors to have different behavior based on the _differentiator_:
+
+```csharp
+class AnyService
+{
+    private readonly _dateFormatAccessor;
+
+    public AnyService(FeatureToggleAccessor<Func<DateTime, String>> dateFormatAccessor)
+    {
+        _dateFormatAccessor = dateFormatAccessor;
+    }
+
+    public string GetNameWithDate(User user)
+    {
+        var differentiator = user.PreferredDateFormat;
+        var date = DateTime.Now;
+        var formattedDate = dateFormatAccessor.Get(differentiator, date));
+        return $"{user.Name} {formattedDate}";
+    }
+}
+```
+
+
 

--- a/Src/MakingSense.DopplerFeatureToggle.Tests/FeatureToggleAccessorBuildingTests.cs
+++ b/Src/MakingSense.DopplerFeatureToggle.Tests/FeatureToggleAccessorBuildingTests.cs
@@ -80,25 +80,25 @@ namespace MakingSense.DopplerFeatureToggle.Tests
 
             var booleanAccessor = client
                 .CreateFeature<bool>("BooleanFeature")
-                .AddBehavior("Disabled", () => false)
-                .AddBehavior("Enabled", () => true)
+                .AddBehavior("Disabled", false)
+                .AddBehavior("Enabled", true)
                 .SetDefaultTreatment("Disabled")
                 .ForceTreatmentIfNotNull(null)
                 .Build();
 
             var forcedBooleanAccessor = client
                 .CreateFeature<bool>("BooleanFeature")
-                .AddBehavior("Disabled", () => false)
-                .AddBehavior("Enabled", () => true)
+                .AddBehavior("Disabled", false)
+                .AddBehavior("Enabled", true)
                 .SetDefaultTreatment("Disabled")
                 .ForceTreatmentIfNotNull("Enabled")
                 .Build();
 
             var dateFormatAccessor = client
                 .CreateFeature<DateTime, string>("DateBehavior")
-                .AddBehavior("ISO", () => x => x.ToString("yyyy-MM-dd"))
-                .AddBehavior("English", () => x => x.ToString("MM/dd/yyyy"))
-                .AddBehavior("Spanish", () => x => x.ToString("dd/MM/yyyy"))
+                .AddBehavior("ISO", x => x.ToString("yyyy-MM-dd"))
+                .AddBehavior("English", x => x.ToString("MM/dd/yyyy"))
+                .AddBehavior("Spanish", x => x.ToString("dd/MM/yyyy"))
                 .SetDefaultTreatment("ISO")
                 .Build();
 
@@ -118,16 +118,11 @@ namespace MakingSense.DopplerFeatureToggle.Tests
             Assert.AreEqual(true, forcedBooleanAccessor.Get("Q"));
             Assert.AreEqual(true, forcedBooleanAccessor.Get("NotExistentDifferentiator"));
 
-            var mauroFormatter = dateFormatAccessor.Get("Mauro");
-            var cristianFormatter = dateFormatAccessor.Get("Cristian");
-            var andresFormatter = dateFormatAccessor.Get("Andres");
-            var defaultFormatter = dateFormatAccessor.Get("NotExistentDifferentiator");
-
             var date = new DateTime(2018, 12, 20);
-            Assert.AreEqual("20/12/2018", mauroFormatter(date));
-            Assert.AreEqual("12/20/2018", cristianFormatter(date));
-            Assert.AreEqual("2018-12-20", andresFormatter(date));
-            Assert.AreEqual("2018-12-20", defaultFormatter(date));
+            Assert.AreEqual("20/12/2018", dateFormatAccessor.Get("Mauro", date));
+            Assert.AreEqual("12/20/2018", dateFormatAccessor.Get("Cristian", date));
+            Assert.AreEqual("2018-12-20", dateFormatAccessor.Get("Andres", date));
+            Assert.AreEqual("2018-12-20", dateFormatAccessor.Get("NotExistentDifferentiator", date));
         }
 
         [Test]
@@ -141,8 +136,8 @@ namespace MakingSense.DopplerFeatureToggle.Tests
             {
                 var booleanAccessor = client
                     .CreateFeature<bool>("BooleanFeature")
-                    .AddBehavior("Disabled", () => false)
-                    .AddBehavior("Enabled", () => true)
+                    .AddBehavior("Disabled", false)
+                    .AddBehavior("Enabled", true)
                     .SetDefaultTreatment("Disabled")
                     .ForceTreatmentIfNotNull("ANOTHER")
                     .Build();
@@ -166,8 +161,8 @@ namespace MakingSense.DopplerFeatureToggle.Tests
             {
                 var booleanAccessor = client
                     .CreateFeature<bool>("BooleanFeature")
-                    .AddBehavior("Disabled", () => false)
-                    .AddBehavior("Enabled", () => true)
+                    .AddBehavior("Disabled", false)
+                    .AddBehavior("Enabled", true)
                     .SetDefaultTreatment("ANOTHER")
                     .Build();
                 Assert.Fail("Expected exception not thrown");
@@ -190,8 +185,8 @@ namespace MakingSense.DopplerFeatureToggle.Tests
             {
                 var booleanAccessor = client
                     .CreateFeature<bool>("BooleanFeature")
-                    .AddBehavior("Disabled", () => false)
-                    .AddBehavior("Enabled", () => true)
+                    .AddBehavior("Disabled", false)
+                    .AddBehavior("Enabled", true)
                     .Build();
                 Assert.Fail("Expected exception not thrown");
             }

--- a/Src/MakingSense.DopplerFeatureToggle.Tests/UpdaterExtensionsTests.cs
+++ b/Src/MakingSense.DopplerFeatureToggle.Tests/UpdaterExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace MakingSense.DopplerFeatureToggle
 
             var due = TimeSpan.FromMilliseconds(200);
             var period = TimeSpan.FromMilliseconds(1000);
-            var testTime = TimeSpan.FromMilliseconds(300);
+            var testTime = TimeSpan.FromMilliseconds(400);
 
             // Act
             var worker = updater.UpdatePeriodically(due, period);

--- a/Src/MakingSense.DopplerFeatureToggle/FeatureToggleClientExtensions.cs
+++ b/Src/MakingSense.DopplerFeatureToggle/FeatureToggleClientExtensions.cs
@@ -85,6 +85,12 @@ namespace MakingSense.DopplerFeatureToggle
             return this;
         }
 
+        public FeatureToggleAccessorBuilder<T> AddBehavior(string treatment, T behavior)
+        {
+            _treatments[treatment] = () => behavior;
+            return this;
+        }
+
         public FeatureToggleAccessorBuilder<T> AddBehavior(string treatment, Func<T> behavior)
         {
             _treatments[treatment] = behavior;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 version: 0.0.1-alpha1-{build}
 image: Visual Studio 2017
 build_script:
-- ps: .\Build\runbuild.ps1 -properties @{buildNuGet=$false}
+- ps: .\runbuild-appveyor.ps1
+artifacts:
+- path: .\Working\NuGet\*.nupkg

--- a/runbuild-appveyor.ps1
+++ b/runbuild-appveyor.ps1
@@ -1,0 +1,7 @@
+﻿$buildNumber = [int]$Env:APPVEYOR_BUILD_NUMBER
+write-host "Build number $buildNumber" -fore white
+$pullRequestNumber = [int]$Env:APPVEYOR_PULL_REQUEST_NUMBER
+write-host "Pull request build number $pullRequestNumber" -fore white
+$formattedBuildNumber = $buildNumber.ToString("D6")
+$nugetPrerelease = "build$formattedBuildNumber"
+Build\runbuild.ps1 -properties @{"nugetPrerelease"=$nugetPrerelease;}


### PR DESCRIPTION
These changes allow generating nuget packages in AppVeyor builds, each nuget package will have his version, for example _0.0.1-alpha1-build000006_
