### PR TITLE
DR-1565 Add builder 

### DIFF
--- a/Src/MakingSense.DopplerFeatureToggle.Tests/FeatureToggleAccessorBuildingTests.cs
+++ b/Src/MakingSense.DopplerFeatureToggle.Tests/FeatureToggleAccessorBuildingTests.cs
@@ -1,0 +1,205 @@
+﻿#region License
+// Copyright (c) 2017 Doppler Relay Team
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using MakingSense.DopplerFeatureToggle.Internal;
+using MakingSense.DopplerFeatureToggle.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using System.Threading;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = MakingSense.DopplerFeatureToggle.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+namespace MakingSense.DopplerFeatureToggle.Tests
+{
+    [TestFixture]
+    public class FeatureToggleAccessorBuildingTests : TestFixtureBase
+    {
+        const string ValidJsonDocument =
+        #region large JSON document
+        @"
+{
+    ""features"": [
+        {
+            ""name"": ""BooleanFeature"",
+            ""treatments"": [
+                { ""name"": ""Enabled"", ""includedDifferentiators"": [ ""N"", ""O"" ] },
+                { ""name"": ""Disabled"", ""includedDifferentiators"": [ ""P"", ""Q"" ] }
+            ]
+        },
+        {
+            ""name"": ""DateBehavior"",
+            ""treatments"": [
+                { ""name"": ""ISO"", ""includedDifferentiators"": [ ""Andres"" ] },
+                { ""name"": ""English"", ""includedDifferentiators"": [ ""Cristian"" ] },
+                { ""name"": ""Spanish"", ""includedDifferentiators"": [ ""Mauro"" ] }
+            ]
+        }
+    ]
+}
+";
+        #endregion
+
+        [Test]
+        public void AccessorBuilding_general_test()
+        {
+            // Arrange
+            var httpClientDouble = new HttpClientDouble();
+            httpClientDouble.Setup_GetString(ValidJsonDocument);
+
+            var client = new HttpFeatureToggleClient(httpClientDouble, "url");
+
+            var booleanAccessor = client
+                .CreateFeature<bool>("BooleanFeature")
+                .AddBehavior("Disabled", () => false)
+                .AddBehavior("Enabled", () => true)
+                .SetDefaultTreatment("Disabled")
+                .ForceTreatmentIfNotNull(null)
+                .Build();
+
+            var forcedBooleanAccessor = client
+                .CreateFeature<bool>("BooleanFeature")
+                .AddBehavior("Disabled", () => false)
+                .AddBehavior("Enabled", () => true)
+                .SetDefaultTreatment("Disabled")
+                .ForceTreatmentIfNotNull("Enabled")
+                .Build();
+
+            var dateFormatAccessor = client
+                .CreateFeature<DateTime, string>("DateBehavior")
+                .AddBehavior("ISO", () => x => x.ToString("yyyy-MM-dd"))
+                .AddBehavior("English", () => x => x.ToString("MM/dd/yyyy"))
+                .AddBehavior("Spanish", () => x => x.ToString("dd/MM/yyyy"))
+                .SetDefaultTreatment("ISO")
+                .Build();
+
+            // Act
+            client.UpdateAsync().Wait();
+
+            // Assert
+            Assert.AreEqual(true, booleanAccessor.Get("N"));
+            Assert.AreEqual(true, booleanAccessor.Get("O"));
+            Assert.AreEqual(false, booleanAccessor.Get("P"));
+            Assert.AreEqual(false, booleanAccessor.Get("Q"));
+            Assert.AreEqual(false, booleanAccessor.Get("NotExistentDifferentiator"));
+
+            Assert.AreEqual(true, forcedBooleanAccessor.Get("N"));
+            Assert.AreEqual(true, forcedBooleanAccessor.Get("O"));
+            Assert.AreEqual(true, forcedBooleanAccessor.Get("P"));
+            Assert.AreEqual(true, forcedBooleanAccessor.Get("Q"));
+            Assert.AreEqual(true, forcedBooleanAccessor.Get("NotExistentDifferentiator"));
+
+            var mauroFormatter = dateFormatAccessor.Get("Mauro");
+            var cristianFormatter = dateFormatAccessor.Get("Cristian");
+            var andresFormatter = dateFormatAccessor.Get("Andres");
+            var defaultFormatter = dateFormatAccessor.Get("NotExistentDifferentiator");
+
+            var date = new DateTime(2018, 12, 20);
+            Assert.AreEqual("20/12/2018", mauroFormatter(date));
+            Assert.AreEqual("12/20/2018", cristianFormatter(date));
+            Assert.AreEqual("2018-12-20", andresFormatter(date));
+            Assert.AreEqual("2018-12-20", defaultFormatter(date));
+        }
+
+        [Test]
+        public void AccessorBuilding_should_not_accept_unexistent_ForceTreatment()
+        {
+            // Arrange
+            var httpClientDouble = new HttpClientDouble();
+            var client = new HttpFeatureToggleClient(httpClientDouble, "url");
+
+            try
+            {
+                var booleanAccessor = client
+                    .CreateFeature<bool>("BooleanFeature")
+                    .AddBehavior("Disabled", () => false)
+                    .AddBehavior("Enabled", () => true)
+                    .SetDefaultTreatment("Disabled")
+                    .ForceTreatmentIfNotNull("ANOTHER")
+                    .Build();
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (Exception e)
+            {
+                Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                Assert.AreEqual("Forced treatment does not match a defined treatment.", e.Message);
+            }
+        }
+
+        [Test]
+        public void AccessorBuilding_should_not_accept_unexistent_DefaultTreatment()
+        {
+            // Arrange
+            var httpClientDouble = new HttpClientDouble();
+            var client = new HttpFeatureToggleClient(httpClientDouble, "url");
+
+            try
+            {
+                var booleanAccessor = client
+                    .CreateFeature<bool>("BooleanFeature")
+                    .AddBehavior("Disabled", () => false)
+                    .AddBehavior("Enabled", () => true)
+                    .SetDefaultTreatment("ANOTHER")
+                    .Build();
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (Exception e)
+            {
+                Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                Assert.AreEqual("Default treatment does not match a defined treatment.", e.Message);
+            }
+        }
+
+        [Test]
+        public void AccessorBuilding_should_require_DefaultTreatment()
+        {
+            // Arrange
+            var httpClientDouble = new HttpClientDouble();
+            var client = new HttpFeatureToggleClient(httpClientDouble, "url");
+
+            try
+            {
+                var booleanAccessor = client
+                    .CreateFeature<bool>("BooleanFeature")
+                    .AddBehavior("Disabled", () => false)
+                    .AddBehavior("Enabled", () => true)
+                    .Build();
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (Exception e)
+            {
+                Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                Assert.AreEqual("Cannot build a feature without default treatment defined.", e.Message);
+            }
+        }
+    }
+}

--- a/Src/MakingSense.DopplerFeatureToggle.Tests/MakingSense.DopplerFeatureToggle.Tests.csproj
+++ b/Src/MakingSense.DopplerFeatureToggle.Tests/MakingSense.DopplerFeatureToggle.Tests.csproj
@@ -4,7 +4,7 @@
       <!-- Required for https://github.com/dotnet/roslyn-project-system/issues/1386 -->
       <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(ResolvedCompileFileDefinitions.Filename)' == 'MakingSense.DopplerFeatureToggle'" />
     </ItemGroup>
-  </Target>  
+  </Target>
   <PropertyGroup>
     <TargetFrameworks Condition="'$(TestFrameworks)'==''">net46;net40;net35;netcoreapp1.1;netcoreapp1.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestFrameworks)'!=''">$(TestFrameworks)</TargetFrameworks>
@@ -24,13 +24,13 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     <ProjectReference Include="..\MakingSense.DopplerFeatureToggle\MakingSense.DopplerFeatureToggle.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="NUnit" Version="3.6.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.5" />
-    <PackageReference Include="FSharp.Core" Version="4.1.2" />    
+    <PackageReference Include="FSharp.Core" Version="4.1.2" />
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
@@ -47,10 +47,10 @@
     <ReferringTargetFrameworkForProjectReferences>.NETFramework,Version=v4.5</ReferringTargetFrameworkForProjectReferences>
     <DefineConstants>NET45;HAVE_BENCHMARKS;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
-    <PackageReference Include="NUnit" Version="3.6.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="FSharp.Core" Version="4.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,10 +65,10 @@
     <AssemblyTitle>DopplerFeatureToggle.NET Tests .NET 4.0</AssemblyTitle>
     <DefineConstants>NET40;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net35'">
-    <PackageReference Include="NUnit" Version="3.6.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <Reference Include="System.Web" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Data.Entity" />
@@ -80,7 +80,7 @@
     <AssemblyTitle>DopplerFeatureToggle.NET Tests .NET 3.5</AssemblyTitle>
     <DefineConstants>NET35;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
     <PackageReference Include="BenchmarkDotNet" Version="0.10.5" />
     <PackageReference Include="FSharp.Core" Version="4.1.2" />
@@ -89,17 +89,17 @@
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />    
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
     <AssemblyTitle>DopplerFeatureToggle.NET Tests .NET Standard 1.3</AssemblyTitle>
     <ReferringTargetFrameworkForProjectReferences>.NETStandard,Version=v1.3</ReferringTargetFrameworkForProjectReferences>
     <DefineConstants>NETSTANDARD1_3;DNXCORE50;PORTABLE;HAVE_BENCHMARKS;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">
     <PackageReference Include="FSharp.Core" Version="4.1.2" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
@@ -108,9 +108,9 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">
     <AssemblyTitle>DopplerFeatureToggle.NET Tests .NET Standard 1.0</AssemblyTitle>

--- a/Src/MakingSense.DopplerFeatureToggle/FeatureToggleClientExtensions.cs
+++ b/Src/MakingSense.DopplerFeatureToggle/FeatureToggleClientExtensions.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MakingSense.DopplerFeatureToggle
+{
+    /// <summary>
+    /// Some extensions to easily create accessors
+    /// </summary>
+    public static class FeatureToggleClientExtensions
+    {
+        public static FeatureToggleAccessorBuilder<T> CreateFeature<T>(
+            this IFeatureToggleClient splitClient,
+            string featureName)
+            => new FeatureToggleAccessorBuilder<T>(splitClient, featureName);
+        public static FeatureToggleAccessorBuilder<TArg, TResult> CreateFeature<TArg, TResult>(
+            this IFeatureToggleClient splitClient,
+            string featureName)
+            => new FeatureToggleAccessorBuilder<TArg, TResult>(splitClient, featureName);
+        public static FeatureToggleAccessorBuilder<TArg1, TArg2, TResult> CreateFeature<TArg1, TArg2, TResult>(
+            this IFeatureToggleClient splitClient,
+            string featureName)
+            => new FeatureToggleAccessorBuilder<TArg1, TArg2, TResult>(splitClient, featureName);
+        public static FeatureToggleAccessorBuilder<TArg1, TArg2, TArg3, TResult> CreateFeature<TArg1, TArg2, TArg3, TResult>(
+            this IFeatureToggleClient splitClient,
+            string featureName)
+            => new FeatureToggleAccessorBuilder<TArg1, TArg2, TArg3, TResult>(splitClient, featureName);
+    }
+
+    /// <summary>
+    /// Some syntactic sugar for accessors
+    /// </summary>
+    public static class FeatureToggleAccessorExtensions
+    {
+        public static TResult Get<TArg, TResult>(
+            this FeatureToggleAccessor<Func<TArg, TResult>> featureToggleAccessor,
+            string differentiator,
+            TArg arg)
+            => featureToggleAccessor.Get(differentiator)(arg);
+        public static TResult Get<TArg1, TArg2, TResult>(
+            this FeatureToggleAccessor<Func<TArg1, TArg2, TResult>> featureToggleAccessor,
+            string differentiator,
+            TArg1 arg1,
+            TArg2 arg2)
+            => featureToggleAccessor.Get(differentiator)(arg1, arg2);
+        public static TResult Get<TArg1, TArg2, TArg3, TResult>(
+            this FeatureToggleAccessor<Func<TArg1, TArg2, TArg3, TResult>> featureToggleAccessor,
+            string differentiator,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3)
+            => featureToggleAccessor.Get(differentiator)(arg1, arg2, arg3);
+    }
+
+    /// <summary>
+    /// Helper class to define accessors
+    /// </summary>
+    public class FeatureToggleAccessorBuilder<T>
+    {
+        private readonly Dictionary<string, Func<T>> _treatments = new Dictionary<string, Func<T>>(StringComparer.OrdinalIgnoreCase);
+        private readonly IFeatureToggleClient _splitClient;
+        private readonly string _featureName;
+        string _defaultTreatment;
+        string _forceTreatment;
+
+        public FeatureToggleAccessorBuilder(IFeatureToggleClient splitClient, string featureName)
+        {
+            _splitClient = splitClient;
+            _featureName = featureName ?? throw new ArgumentNullException(nameof(featureName));
+        }
+
+        public FeatureToggleAccessor<T> Build()
+            => new FeatureToggleAccessor<T>(
+                _splitClient,
+                _featureName,
+                _defaultTreatment,
+                _forceTreatment,
+                _treatments);
+
+        public FeatureToggleAccessorBuilder<T> SetDefaultTreatment(string treatment)
+        {
+            _defaultTreatment = treatment ?? throw new ArgumentNullException(nameof(treatment));
+            return this;
+        }
+
+        public FeatureToggleAccessorBuilder<T> AddBehavior(string treatment, Func<T> behavior)
+        {
+            _treatments[treatment] = behavior;
+            return this;
+        }
+
+        /// <summary>
+        /// If treatmentName is null, it will not be forced
+        /// </summary>
+        public FeatureToggleAccessorBuilder<T> ForceTreatmentIfNotNull(string behaviorName)
+        {
+            _forceTreatment = string.IsNullOrEmpty(behaviorName)
+                ? null
+                : behaviorName;
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Helper class to define accessors
+    /// </summary>
+    public class FeatureToggleAccessorBuilder<TArg, TResult> : FeatureToggleAccessorBuilder<Func<TArg, TResult>>
+    {
+        public FeatureToggleAccessorBuilder(IFeatureToggleClient splitClient, string featureName)
+            : base(splitClient, featureName) { }
+        public FeatureToggleAccessorBuilder<TArg, TResult> AddBehavior(
+            string treatment,
+            Func<TArg, TResult> behavior)
+            => (FeatureToggleAccessorBuilder<TArg, TResult>)AddBehavior(treatment, () => behavior);
+    }
+
+    /// <summary>
+    /// Helper class to define accessors
+    /// </summary>
+    public class FeatureToggleAccessorBuilder<TArg1, TArg2, TResult> : FeatureToggleAccessorBuilder<Func<TArg1, TArg2, TResult>>
+    {
+        public FeatureToggleAccessorBuilder(IFeatureToggleClient splitClient, string featureName)
+            : base(splitClient, featureName) { }
+        public FeatureToggleAccessorBuilder<TArg1, TArg2, TResult> AddBehavior(
+            string treatment,
+            Func<TArg1, TArg2, TResult> behavior)
+            => (FeatureToggleAccessorBuilder<TArg1, TArg2, TResult>)AddBehavior(treatment, () => behavior);
+    }
+
+    /// <summary>
+    /// Helper class to define accessors
+    /// </summary>
+    public class FeatureToggleAccessorBuilder<TArg1, TArg2, TArg3, TResult> : FeatureToggleAccessorBuilder<Func<TArg1, TArg2, TArg3, TResult>>
+    {
+        public FeatureToggleAccessorBuilder(IFeatureToggleClient splitClient, string featureName)
+            : base(splitClient, featureName) { }
+        public FeatureToggleAccessorBuilder<TArg1, TArg2, TArg3, TResult> AddBehavior(
+            string treatment,
+            Func<TArg1, TArg2, TArg3, TResult> behavior)
+            => (FeatureToggleAccessorBuilder<TArg1, TArg2, TArg3, TResult>)AddBehavior(treatment, () => behavior);
+    }
+}


### PR DESCRIPTION
@MakingSense/never-pony  (spam because there is no one subscriber and maybe they want to hear about this improvement) 

With this change, it is not necessary anymore to create classes for each accessor, for example:

```cs
            var booleanAccessor = client
                .CreateFeature<bool>("BooleanFeature")
                .AddBehavior("Disabled", () => false)
                .AddBehavior("Enabled", () => true)
                .SetDefaultTreatment("Disabled")
                .ForceTreatmentIfNotNull(null)
                .Build();

            var forcedBooleanAccessor = client
                .CreateFeature<bool>("BooleanFeature")
                .AddBehavior("Disabled", () => false)
                .AddBehavior("Enabled", () => true)
                .SetDefaultTreatment("Disabled")
                .ForceTreatmentIfNotNull("Enabled")
                .Build();

            var dateFormatAccessor = client
                .CreateFeature<DateTime, string>("DateBehavior")
                .AddBehavior("ISO", () => x => x.ToString("yyyy-MM-dd"))
                .AddBehavior("English", () => x => x.ToString("MM/dd/yyyy"))
                .AddBehavior("Spanish", () => x => x.ToString("dd/MM/yyyy"))
                .SetDefaultTreatment("ISO")
                .Build();
```